### PR TITLE
Create asus-pv100a-4.14.98-1.0.0-1.xml

### DIFF
--- a/asus-pv100a-4.14.98-1.0.0-1.xml
+++ b/asus-pv100a-4.14.98-1.0.0-1.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+
+  <default sync-j="2"/>
+
+  <remote fetch="git://git.yoctoproject.org"                 name="yocto"/>
+  <remote fetch="git://github.com/Freescale"                 name="community"/>
+  <remote fetch="git://github.com/openembedded"              name="oe"/>
+  <remote fetch="git://github.com/OSSystems"                 name="OSSystems"/>
+  <remote fetch="git://github.com/meta-qt5"                  name="QT5"/>
+  <remote fetch="https://source.codeaurora.org/external/imx" name="CAF"/>
+  <remote fetch="git://github.com/Azure"                     name="Azure"/>
+  <remote fetch="git://github.com/meta-rust"                 name="rust"/>
+  <remote fetch="https://github.com/ASUS-IPC"                name="asus"/>
+
+
+  <project remote="yocto"     revision="c9bd4984f8f471ca2c43052714f4413ba99cf171" name="poky"                    path="sources/poky"/>
+  <project remote="yocto"     revision="27ca94f8a4336790ba117b4298566f6820e7e74c" name="meta-freescale"          path="sources/meta-freescale"/>
+  <project remote="oe"        revision="8760facba1bceb299b3613b8955621ddaa3d4c3f" name="meta-openembedded"       path="sources/meta-openembedded"/>
+  <project remote="community" revision="82037216280a39957fb4272581637abec734ad50" name="meta-freescale-3rdparty" path="sources/meta-freescale-3rdparty"/>
+  <project remote="community" revision="f7e2216e93aff14ac32728a13637a48df436b7f4" name="meta-freescale-distro"   path="sources/meta-freescale-distro"/>
+  <project remote="CAF"       revision="8eeb420fad668b733ab95b460895e1c337c66b25" name="meta-fsl-bsp-release"    path="sources/meta-fsl-bsp-release" >
+     <linkfile src="imx/tools/fsl-setup-release.sh" dest="fsl-setup-release.sh"/>
+     <linkfile src="imx/README"                     dest="README-IMXBSP"/>
+  </project>
+  <project remote="OSSystems" revision="75640e14e325479c076b6272b646be7a239c18aa" name="meta-browser"            path="sources/meta-browser" />
+  <project remote="QT5"       revision="d4e7f73d04e8448d326b6f89908701e304e37d65" name="meta-qt5"                path="sources/meta-qt5" />
+  <project remote="rust"      revision="c72b2dda3a4f70ed257c7de9bedb4b04732970a4" name="meta-rust"               path="sources/meta-rust"/>
+  <project remote="yocto"     revision="ed2038c935777d1336c17989d454f4e9c95fea7f" name="meta-virtualization"     path="sources/meta-virtualization"/>  
+  <project remote="asus"      revision="3168ff257cc5d174444ce5fd7e958ff172deb930" name="meta-iotedge"            path="sources/meta-iotedge"/>
+  <project remote="asus"      revision="050969a50967ba3303d23583f35901b68651d150" name="meta-asus-imx"           path="sources/meta-asus-imx"/>
+  <project remote="asus"      revision="a31e1e1a26052f70eece6c24fe96b4fe4dfdd418" name="asus-bsp-base"           path="sources/base" >
+    <linkfile src="README"            dest="README" />
+    <linkfile src="setup-environment" dest="setup-environment" />
+  </project>
+  <project remote="asus"      revision="60b79a24854400bc925c80f260fdde7c47189a3b" name="docker_builder"          path="docker_builder"/>
+
+</manifest>


### PR DESCRIPTION
asus-pv100a-4.14.98-1.0.0-1 and asus-pv100a-4.14.98-1.0.0 are roughly the same.
The new modification for asus-pv100a-4.14.98-1.0.0-1 is to solve the build failed. The reason for the build failed is because the name of some branches was changed from master to main